### PR TITLE
Delete UCPD (User Choice Protection Driver)

### DIFF
--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -153,6 +153,15 @@ actions:
   - !file:
     path: "%ProgramFiles(x86)%\\Microsoft"
     weight: 30
+  - !file:
+    path: "%windir%\\System32\\drivers\\UCPD.sys"
+  - !service:
+    name: "UCPD"
+    operation: delete
+    device: true
+  - !scheduledTask:
+    path: "\\Microsoft\\Windows\\AppxDeploymentClient\\UCPD velocity"
+    operation: delete
   - !service:
     name: "applockerfltr"
     operation: delete

--- a/src/Configuration/tasks/regedits.yml
+++ b/src/Configuration/tasks/regedits.yml
@@ -362,6 +362,9 @@ actions:
   - !registryValue: {option: "ui", path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced', value: 'TaskbarAl', type: REG_DWORD, data: '0'}
   - !registryValue: {option: "ui", path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced', value: 'NavPaneShowAllFolders', type: REG_DWORD, data: '0'}
 
+  # Reduce friction for app defaults
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer', value: 'NoNewAppAlert', type: REG_DWORD, data: '1'}
+
     # Taskbar
 #  - !registryValue: {path: 'HKCU\SOFTWARE\Policies\Microsoft\Windows\Explorer', value: 'DisableNotificationCenter', type: REG_DWORD, data: '1'}
   - !registryValue: {path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced', value: 'ShowCortanaButton', type: REG_DWORD, data: '0'}


### PR DESCRIPTION
UCPD (User Choice Protection Driver) was added in 24H2 to enforce restrictions on software defaults, app associations and links. While technically a security feature as certain malicious software does modify these defaults in order to persist on a user's system, this driver mostly ends up breaking software installs that would otherwise work on Windows 10. Setting file associations through the Settings app as documentation suggests only works half the time.
Notably installation of an file archiving utility, an image viewer is still likely "damaged" by UCPD - file associations for archives and images must be set manually per file extension.

Additionally, certain file extensions in Windows 11 are "protected" and thus cannot be set by a program by default (see [reference](https://setuserfta.com/legacy-file-type-associations/)). This includes media formats, browser formats and archive formats supported by Explorer as of 24H2. This also includes extensions that already have at least one registered handler. To reduce the friction in regard to the "Open with" window, an additional "NoNewAppAlert" policy was added that appears to help.