### PR TITLE
Delete wlidsvc (Microsoft Account Sign-in Assistant)

### DIFF
--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -62,8 +62,8 @@ actions:
     name: "OneDrive"
   - !taskKill:
     name: "msiexec"
-#  - !file:
-#    path: "%windir%\\System32\\wlidsvc.dll"
+  - !file:
+    path: "%windir%\\System32\\wlidsvc.dll"
   - !file:
     path: "%windir%\\System32\\WpcDesktopMonSvc.dll"
   - !file:

--- a/src/Configuration/tasks/services.yml
+++ b/src/Configuration/tasks/services.yml
@@ -159,9 +159,9 @@ actions:
   - !service: {name: 'BITS', operation: change, startup: 3}
 
     # Breaks APPX installation sometimes
-#  - !service:
-#    name: "wlidsvc"
-#    operation: delete
+  - !service:
+    name: "wlidsvc"
+    operation: delete
   - !run: {exeDir: true, exe: "SERVICE.bat", weight: 20}
 #  - !run: {exeDir: true, exe: 'ISO\SERVICE.bat', weight: 20, oobe: true}
 


### PR DESCRIPTION
This is something of a working theory based on limited testing and may not be accurate.

APPX packages distributed through Microsoft Store can/must require a digital license to be provided to them in order to start. This digital license is acquired by ClipSVC (Client License Service) and is stored in `ProgramData\Microsoft\Windows\ClipSvc`, acquired from licensing.mp.microsoft.com.

IF wlidsvc exists and is startable/running, before ClipSVC ends up requesting a license, wlidsvc MUST contact login.live.com (presumably, to get authentication token for paid apps/tie license to account for later app downloads). If wlidsvc is unable to do that (e.g. if firewalled), ClipSVC stalls and is unable to procure licenses, hence APPX does not launch.

IF NOT, ClipSVC skips the middleman and gets the license normally.

Arguably, the presence of such home phoning in place of login.live.com (as stated in testing methodology) doesn't really cut down the telemetry, but wlidsvc (under certain circumstances) constantly calls login.live.com which is worse.