### PR TITLE
Remove Edge, OneDrive, Defender, Sense from WinSxS

### DIFF
--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -675,3 +675,13 @@ actions:
     path: "%windir%\\System32\\wuaueng.dll"
   - !file:
     path: "%windir%\\System32\\MRT.exe"
+  - !file:
+    path: "%windir%\\System32\\Microsoft-Edge-WebView"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-edge*"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-windows-onedrive*"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_windows-defender*"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_windows-senseclient*"


### PR DESCRIPTION
WinSxS still contains components approx. 1.5 GB in size that cannot be used in an Ameliorated system. As uninstallation requires an ISO image, there's no loss in removing them. Also Edge WebView is there for some reason.