### PR TITLE
Restore Delivery Optimization (DoSvc)

### DIFF
--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -335,12 +335,12 @@ actions:
     path: "%windir%\\System32\\Tasks\\Microsoft\\Windows\\Feedback\\Siuf\\DmClientOnScenarioDownload"
   - !file:
     path: "%windir%\\System32\\omadmclient.exe"
-  - !file:
-    path: "%windir%\\System32\\dosvc.dll"
-  - !file:
-    path: "%windir%\\System32\\en-US\\dosvc.dll.mui"
-  - !file:
-    path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization"
+  #- !file:
+  #  path: "%windir%\\System32\\dosvc.dll"
+  #- !file:
+  #  path: "%windir%\\System32\\en-US\\dosvc.dll.mui"
+  #- !file:
+  #  path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization"
   - !file:
     path: "%windir%\\PolicyDefinitions\\EnhancedStorage.admx"
   - !file:

--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -215,24 +215,24 @@ actions:
     path: "%windir%\\System32\\ClipUp.exe"
   - !file:
     path: "%windir%\\System32\\DeliveryOptimizationMIProv.mof"
-  - !file:
-    path: "%windir%\\PolicyDefinitions\\DeliveryOptimization.admx"
+  #- !file:
+  #  path: "%windir%\\PolicyDefinitions\\DeliveryOptimization.admx"
   - !file:
     path: "%windir%\\System32\\DeliveryOptimizationMIProvUninstall.mof"
-  - !file:
-    path: "%windir%\\PolicyDefinitions\\en-US\\DeliveryOptimization.adml"
-  - !file:
-    path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimization.psd1"
-  - !file:
-    path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimization.psd1"
-  - !file:
-    path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationStatus.psm1"
-  - !file:
-    path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationStatus.psm1"
-  - !file:
-    path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationVerboseLogs.psm1"
-  - !file:
-    path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationVerboseLogs.psm1"
+  #- !file:
+  #  path: "%windir%\\PolicyDefinitions\\en-US\\DeliveryOptimization.adml"
+  #- !file:
+  #  path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimization.psd1"
+  #- !file:
+  #  path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimization.psd1"
+  #- !file:
+  #  path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationStatus.psm1"
+  #- !file:
+  #  path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationStatus.psm1"
+  #- !file:
+  #  path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationVerboseLogs.psm1"
+  #- !file:
+  #  path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\DeliveryOptimizationVerboseLogs.psm1"
   - !file:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\State\\migration.dat"
   - !taskKill:
@@ -249,10 +249,10 @@ actions:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\State\\dosvcState.dat.LOG1"
   - !file:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\State\\dosvcState.dat.LOG2"
-  - !file:
-    path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\Microsoft.Windows.DeliveryOptimization.AdminCommands.dll"
-  - !file:
-    path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\Microsoft.Windows.DeliveryOptimization.AdminCommands.dll"
+  #- !file:
+  #  path: "%windir%\\System32\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\Microsoft.Windows.DeliveryOptimization.AdminCommands.dll"
+  #- !file:
+  #  path: "%windir%\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules\\DeliveryOptimization\\Microsoft.Windows.DeliveryOptimization.AdminCommands.dll"
   - !file:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\Logs\\dosvc.20201119_074736_959.etl"
   - !file:

--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -238,6 +238,9 @@ actions:
   - !taskKill:
     name: "LogonUI"
     ignoreErrors: true
+
+  - !service: {name: 'DoSvc', operation: change, startup: 4}
+  - !service: {name: 'DoSvc', operation: stop}
   - !file:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\State\\dosvcState.dat"
     ignoreErrors: true
@@ -279,6 +282,8 @@ actions:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\Logs\\domgmt.20210401_011537_705.etl"
   - !file:
     path: "%windir%\\ServiceProfiles\\NetworkService\\AppData\\Local\\Microsoft\\Windows\\DeliveryOptimization\\Logs\\domgmt.20210424_232442_384.etl"
+  - !service: {name: 'DoSvc', operation: change, startup: 3}
+
   - !file:
     path: "%windir%\\System32\\DeviceCensus.exe"
   - !file:

--- a/src/Configuration/tasks/regedits.yml
+++ b/src/Configuration/tasks/regedits.yml
@@ -31,7 +31,7 @@ actions:
   - !registryValue: {path: 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Policies\DataCollection', value: 'AllowTelemetry', type: REG_DWORD, data: '0'}
   - !registryValue: {path: 'HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\AutoLogger-Diagtrack-Listener', value: 'Start', type: REG_DWORD, data: '0'}
   - !registryValue: {path: 'HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\SQMLogger', value: 'Start', type: REG_DWORD, data: '0'}
-  - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config', value: 'DownloadMode', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config', value: 'DownloadMode', type: REG_DWORD, data: '99'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\SettingSync', value: 'DisableSettingSync', type: REG_DWORD, data: '2'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\SettingSync', value: 'DisableSettingSyncUserOverride', type: REG_DWORD, data: '1'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo', value: 'DisabledByGroupPolicy', type: REG_DWORD, data: '1'}

--- a/src/Configuration/tasks/regedits.yml
+++ b/src/Configuration/tasks/regedits.yml
@@ -31,7 +31,7 @@ actions:
   - !registryValue: {path: 'HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Policies\DataCollection', value: 'AllowTelemetry', type: REG_DWORD, data: '0'}
   - !registryValue: {path: 'HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\AutoLogger-Diagtrack-Listener', value: 'Start', type: REG_DWORD, data: '0'}
   - !registryValue: {path: 'HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\SQMLogger', value: 'Start', type: REG_DWORD, data: '0'}
-  - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config', value: 'DownloadMode', type: REG_DWORD, data: '99'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization', value: 'DODownloadMode', type: REG_DWORD, data: '99'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\SettingSync', value: 'DisableSettingSync', type: REG_DWORD, data: '2'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\SettingSync', value: 'DisableSettingSyncUserOverride', type: REG_DWORD, data: '1'}
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo', value: 'DisabledByGroupPolicy', type: REG_DWORD, data: '1'}

--- a/src/Configuration/tasks/services.yml
+++ b/src/Configuration/tasks/services.yml
@@ -86,9 +86,10 @@ actions:
   - !service:
     name: "BITS"
     operation: stop
-  - !service:
-    name: "DoSvc"
-    operation: delete
+  # Breaks certain installation of APPX packages when removed/disabled
+  #- !service:
+  #  name: "DoSvc"
+  #  operation: delete
   - !service:
     name: "iphlpsvc"
     operation: stop

--- a/src/Configuration/tasks/services.yml
+++ b/src/Configuration/tasks/services.yml
@@ -87,9 +87,9 @@ actions:
     name: "BITS"
     operation: stop
   # Breaks certain installation of APPX packages when removed/disabled
-  - !service:
-    name: "DoSvc"
-    operation: stop
+  #- !service:
+  #  name: "DoSvc"
+  #  operation: delete
   - !service:
     name: "iphlpsvc"
     operation: stop

--- a/src/Configuration/tasks/services.yml
+++ b/src/Configuration/tasks/services.yml
@@ -87,9 +87,9 @@ actions:
     name: "BITS"
     operation: stop
   # Breaks certain installation of APPX packages when removed/disabled
-  #- !service:
-  #  name: "DoSvc"
-  #  operation: delete
+  - !service:
+    name: "DoSvc"
+    operation: stop
   - !service:
     name: "iphlpsvc"
     operation: stop


### PR DESCRIPTION
WinGet (or APPX-based services?) has an undocumented dependency on Delivery Optimization. This PR restores the service and modifies download mode to 99:
> 	Simple mode disables the use of Delivery Optimization cloud services completely (for offline environments). Delivery Optimization switches to this mode automatically when the Delivery Optimization cloud services are unavailable, unreachable, or when the content file size is less than 50 MB, as the default. In this mode, Delivery Optimization provides a reliable download experience over HTTP from the download's original source or a Microsoft Connected Cache server, with no peer-to-peer caching.

Coarse testing revealed this appears to be the case. This **does** fix certain APPX packages that depend on it to download and install properly. This **does not** fix the msstore source which appears to require additional services (but not Microsoft Store itself).