### PR TITLE
Complete revamp of component removal

### DIFF
--- a/src/Configuration/tasks/appx.yml
+++ b/src/Configuration/tasks/appx.yml
@@ -5,7 +5,7 @@ privilege: TrustedInstaller
 actions:
   - !status: {status: 'Removing APPX packages'}
   - !appx: {name: '*3DViewer*', type: family}
-  - !appx: {name: '*ApplicationCompatbilityEnhancements*', type: family}
+  - !appx: {name: '*ApplicationCompatibilityEnhancements*', type: family}
   - !appx: {name: '*Apprep.Chx*', type: family}
   - !appx: {name: '*AssignedAccessLockApp*', type: family}
   - !appx: {name: '*AugLoop.CBS*', type: family}

--- a/src/Configuration/tasks/appx.yml
+++ b/src/Configuration/tasks/appx.yml
@@ -5,8 +5,10 @@ privilege: TrustedInstaller
 actions:
   - !status: {status: 'Removing APPX packages'}
   - !appx: {name: '*3DViewer*', type: family}
+  - !appx: {name: '*ApplicationCompatbilityEnhancements*', type: family}
   - !appx: {name: '*Apprep.Chx*', type: family}
   - !appx: {name: '*AssignedAccessLockApp*', type: family}
+  - !appx: {name: '*AugLoop.CBS*', type: family}
   - !appx: {name: '*Bing*', type: family}
   - !appx: {name: '*CamoStudio*', type: family}
   - !appx: {name: '*Client.WebExperience*', type: family}
@@ -15,6 +17,7 @@ actions:
   - !appx: {name: '*CommsPhone*', type: family}
   - !appx: {name: '*ConnectivityStore*', type: family}
   - !appx: {name: '*ContentDeliveryManager*', type: family}
+  - !appx: {name: '*CrossDevice*', type: family}
   - !appx: {name: '*Disney*', type: family}
   - !appx: {name: '*FeedbackHub*', type: family}
   - !appx: {name: '*GamingApp*', type: family}
@@ -51,8 +54,11 @@ actions:
   - !appx: {name: '*Sticky*', type: family}
   - !appx: {name: '*StorePurchaseApp*', type: family}
   - !appx: {name: '*Sway*', type: family}
+  - !appx: {name: '*UndockedDevKit*', type: family}
   - !appx: {name: '*Wallet*', type: family}
   - !appx: {name: '*WebExperienceHost*', type: app}
+  - !appx: {name: '*WidgetsPlatformRuntime*', type: family}
+  - !appx: {name: '*Win32WebViewHost*', type: family}
   - !appx: {name: '*Windows.DevHome*', type: family}
   - !appx: {name: '*WindowsCamera*', type: family}
   - !appx: {name: '*windowscommunicationsapps*', type: family}
@@ -64,7 +70,7 @@ actions:
   - !appx: {name: '*XboxGameCallableUI*', type: family}
   - !appx: {name: '*XboxGameOverlay*', type: family}
   - !appx: {name: '*XboxGamingOverlay*', type: family}
-  - !appx: {name: '*XboxIdenitity*', type: family}
+  - !appx: {name: '*XboxIdentity*', type: family}
   - !appx: {name: '*XboxSpeechToTextOverlay*', type: family}
   - !appx: {name: '*YourPhone*', type: family}
   - !appx: {name: '*Zune*', type: family}

--- a/src/Configuration/tasks/appx.yml
+++ b/src/Configuration/tasks/appx.yml
@@ -6,6 +6,7 @@ actions:
   - !status: {status: 'Removing APPX packages'}
   - !appx: {name: '*3DViewer*', type: family}
   - !appx: {name: '*ApplicationCompatibilityEnhancements*', type: family}
+  - !appx: {name: '*AIFabric.CBS*', type: family}
   - !appx: {name: '*Apprep.Chx*', type: family}
   - !appx: {name: '*AssignedAccessLockApp*', type: family}
   - !appx: {name: '*AugLoop.CBS*', type: family}

--- a/src/Configuration/tasks/components.yml
+++ b/src/Configuration/tasks/components.yml
@@ -7,22 +7,22 @@ actions:
   - !registryValue: {path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband', value: 'Favorites', type: REG_BINARY, data: '00A40100003A001F80C827341F105C1042AA032EE45287D668260001002600EFBE120000001A1E97454EEFD801757130704EEFD8015EB737704EEFD801140056003100000000006355693411005461736B42617200400009000400EFBE63556934635569342E0000009D8A0100000001000000000000000000000000000000A29F33005400610073006B00420061007200000016001201320097010000A754662A200046494C4545587E312E4C4E4B00007C0009000400EFBE63556934635569342E0000009E8A0100000001000000000000000000520000000000A413A200460069006C00650020004500780070006C006F007200650072002E006C006E006B00000040007300680065006C006C00330032002E0064006C006C002C002D003200320030003600370000001C00120000002B00EFBE22283A704EEFD8011C00420000001D00EFBE02004D006900630072006F0073006F00660074002E00570069006E0064006F00770073002E004500780070006C006F0072006500720000001C00260000001E00EFBE0200530079007300740065006D00500069006E006E006500640000001C000000FF'}
   - !registryValue: {path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband', value: 'FavoritesResolve', type: REG_BINARY, data: '330300004C0000000114020000000000C0000000000000468300800020000000E7E332704EEFD80122283A704EEFD8015CF4E1FBD161D801970100000000000001000000000000000000000000000000A0013A001F80C827341F105C1042AA032EE45287D668260001002600EFBE120000001A1E97454EEFD801757130704EEFD8015EB737704EEFD801140056003100000000006355693411005461736B42617200400009000400EFBE63556934635569342E0000009D8A0100000001000000000000000000000000000000A29F33005400610073006B00420061007200000016000E01320097010000A754662A200046494C4545587E312E4C4E4B00007C0009000400EFBE63556934635569342E0000009E8A0100000001000000000000000000520000000000A413A200460069006C00650020004500780070006C006F007200650072002E006C006E006B00000040007300680065006C006C00330032002E0064006C006C002C002D003200320030003600370000001C00220000001E00EFBE02005500730065007200500069006E006E006500640000001C00120000002B00EFBE22283A704EEFD8011C00420000001D00EFBE02004D006900630072006F0073006F00660074002E00570069006E0064006F00770073002E004500780070006C006F0072006500720000001C0000009C0000001C000000010000001C0000002D000000000000009B000000110000000300000013EBC8041000000000433A5C55736572735C4D634E696E5C417070446174615C526F616D696E675C4D6963726F736F66745C496E7465726E6574204578706C6F7265725C517569636B204C61756E63685C557365722050696E6E65645C5461736B4261725C46696C65204578706C6F7265722E6C6E6B000060000000030000A058000000000000006465736B746F702D666A63716F626D00A84D9F7C73D4F344BF15FAA23DFD8B4733F18E66405BED11AA54000C29341E2EA84D9F7C73D4F344BF15FAA23DFD8B4733F18E66405BED11AA54000C29341E2E45000000090000A03900000031535053B1166D44AD8D7048A748402EA43D788C1D0000006800000000480000009B7B87BF89DF6547B6A80DC335F1C9BF000000000000000000000000'}
 
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-Services45 -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-PortSharing45 -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName MediaPlayback -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName SmbDirect -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName Windows-Defender-Default-Definitions -All"}
-  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName NetFx4-AdvSrvs -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-Services45"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-PortSharing45"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName MediaPlayback"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName SmbDirect"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName Windows-Defender-Default-Definitions"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName NetFx4-AdvSrvs"}
 
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name App.StepsRecorder"}
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name MathRecognizer"}
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name Media.WindowsMediaPlayer"}
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name Microsoft.Windows.PowerShell.ISE"}
-  - !powerShell: {command: "Remove-WindowsCapability -Online -Name Microsoft.Windows.Sense.Client"}
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name OpenCoreUAP.OneSync"}
   - !powerShell: {command: "Remove-WindowsCapability -Online -Name VBSCRIPT"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name Browser.InternetExplorer"}
 
     # ---------- Windows Defender
   - !status: {status: 'Removing Windows Defender'}
@@ -63,8 +63,6 @@ actions:
   - !scheduledTask:
     path: "\\Microsoft\\Windows\\Windows Defender\\Windows Defender Verification"
     operation: delete
-
-  - !systemPackage: {name: 'Windows-Defender*', arch: all, language: '*'}
 
     # ---------- Microsoft Edge
   - !status: {status: 'Removing Microsoft Edge'}
@@ -109,8 +107,6 @@ actions:
   - !registryKey: {path: 'HKCR\WOW6432Node\CLSID\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}'}
   - !registryKey: {path: 'HKCR\ie_to_edge_bho.IEToEdgeBHO'}
   - !registryKey: {path: 'HKCR\ie_to_edge_bho.IEToEdgeBHO.1'}
-
-  - !systemPackage: {name: 'Microsoft-Edge*', arch: all, language: '*'}
 
     # Internet Explorer
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Internet Explorer\Main\EnterpriseMode', value: 'MSEdgePath', operation: delete}
@@ -504,6 +500,3 @@ actions:
   - !registryKey: {path: 'HKCR\ms-office-ai', operation: delete}
   - !registryKey: {path: 'HKCR\ms-copilot', operation: delete}
   - !registryKey: {path: 'HKCR\ms-clicktodo', operation: delete}
-
-  - !systemPackage: {name: 'Windows-Sense*', arch: all, language: '*'}
-  - !systemPackage: {name: 'Microsoft-Windows-OneDrive*', arch: all, language: '*'}

--- a/src/Configuration/tasks/components.yml
+++ b/src/Configuration/tasks/components.yml
@@ -7,6 +7,23 @@ actions:
   - !registryValue: {path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband', value: 'Favorites', type: REG_BINARY, data: '00A40100003A001F80C827341F105C1042AA032EE45287D668260001002600EFBE120000001A1E97454EEFD801757130704EEFD8015EB737704EEFD801140056003100000000006355693411005461736B42617200400009000400EFBE63556934635569342E0000009D8A0100000001000000000000000000000000000000A29F33005400610073006B00420061007200000016001201320097010000A754662A200046494C4545587E312E4C4E4B00007C0009000400EFBE63556934635569342E0000009E8A0100000001000000000000000000520000000000A413A200460069006C00650020004500780070006C006F007200650072002E006C006E006B00000040007300680065006C006C00330032002E0064006C006C002C002D003200320030003600370000001C00120000002B00EFBE22283A704EEFD8011C00420000001D00EFBE02004D006900630072006F0073006F00660074002E00570069006E0064006F00770073002E004500780070006C006F0072006500720000001C00260000001E00EFBE0200530079007300740065006D00500069006E006E006500640000001C000000FF'}
   - !registryValue: {path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband', value: 'FavoritesResolve', type: REG_BINARY, data: '330300004C0000000114020000000000C0000000000000468300800020000000E7E332704EEFD80122283A704EEFD8015CF4E1FBD161D801970100000000000001000000000000000000000000000000A0013A001F80C827341F105C1042AA032EE45287D668260001002600EFBE120000001A1E97454EEFD801757130704EEFD8015EB737704EEFD801140056003100000000006355693411005461736B42617200400009000400EFBE63556934635569342E0000009D8A0100000001000000000000000000000000000000A29F33005400610073006B00420061007200000016000E01320097010000A754662A200046494C4545587E312E4C4E4B00007C0009000400EFBE63556934635569342E0000009E8A0100000001000000000000000000520000000000A413A200460069006C00650020004500780070006C006F007200650072002E006C006E006B00000040007300680065006C006C00330032002E0064006C006C002C002D003200320030003600370000001C00220000001E00EFBE02005500730065007200500069006E006E006500640000001C00120000002B00EFBE22283A704EEFD8011C00420000001D00EFBE02004D006900630072006F0073006F00660074002E00570069006E0064006F00770073002E004500780070006C006F0072006500720000001C0000009C0000001C000000010000001C0000002D000000000000009B000000110000000300000013EBC8041000000000433A5C55736572735C4D634E696E5C417070446174615C526F616D696E675C4D6963726F736F66745C496E7465726E6574204578706C6F7265725C517569636B204C61756E63685C557365722050696E6E65645C5461736B4261725C46696C65204578706C6F7265722E6C6E6B000060000000030000A058000000000000006465736B746F702D666A63716F626D00A84D9F7C73D4F344BF15FAA23DFD8B4733F18E66405BED11AA54000C29341E2EA84D9F7C73D4F344BF15FAA23DFD8B4733F18E66405BED11AA54000C29341E2E45000000090000A03900000031535053B1166D44AD8D7048A748402EA43D788C1D0000006800000000480000009B7B87BF89DF6547B6A80DC335F1C9BF000000000000000000000000'}
 
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-Services45 -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WCF-TCP-PortSharing45 -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName MediaPlayback -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName SmbDirect -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName Windows-Defender-Default-Definitions -All"}
+  - !powerShell: {command: "Disable-WindowsOptionalFeature -Online -FeatureName NetFx4-AdvSrvs -All"}
+
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name App.StepsRecorder"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name MathRecognizer"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name Media.WindowsMediaPlayer"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name Microsoft.Windows.PowerShell.ISE"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name Microsoft.Windows.Sense.Client"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name OpenCoreUAP.OneSync"}
+  - !powerShell: {command: "Remove-WindowsCapability -Online -Name VBSCRIPT"}
+
     # ---------- Windows Defender
   - !status: {status: 'Removing Windows Defender'}
   - !taskKill: {name: "NisSrv"}
@@ -46,6 +63,8 @@ actions:
   - !scheduledTask:
     path: "\\Microsoft\\Windows\\Windows Defender\\Windows Defender Verification"
     operation: delete
+
+  - !systemPackage: {name: 'Windows-Defender*', arch: all, language: '*'}
 
     # ---------- Microsoft Edge
   - !status: {status: 'Removing Microsoft Edge'}
@@ -90,6 +109,8 @@ actions:
   - !registryKey: {path: 'HKCR\WOW6432Node\CLSID\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}'}
   - !registryKey: {path: 'HKCR\ie_to_edge_bho.IEToEdgeBHO'}
   - !registryKey: {path: 'HKCR\ie_to_edge_bho.IEToEdgeBHO.1'}
+
+  - !systemPackage: {name: 'Microsoft-Edge*', arch: all, language: '*'}
 
     # Internet Explorer
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Internet Explorer\Main\EnterpriseMode', value: 'MSEdgePath', operation: delete}
@@ -147,7 +168,7 @@ actions:
   - !registryKey: {path: 'HKLM\SOFTWARE\Microsoft\Internet Explorer'}
   - !registryValue: {path: 'HKLM\SOFTWARE\RegisteredApplications', value: 'Internet Explorer', operation: delete}
 
-  - !systemPackage: {name: 'Microsoft-Windows-Internet-Browser-Deployment', arch: amd64, language: 'neutral'}
+  - !systemPackage: {name: 'Microsoft-Windows-Internet-Browser-Deployment', arch: all, language: '*'}
 
   - !file: {path: '%SYSTEMDRIVE%\Users\Public\Desktop\Microsoft Edge.lnk'}
   - !file: {path: "%ProgramFiles(x86)%\\Microsoft\\Edge", weight: 10}
@@ -483,3 +504,6 @@ actions:
   - !registryKey: {path: 'HKCR\ms-office-ai', operation: delete}
   - !registryKey: {path: 'HKCR\ms-copilot', operation: delete}
   - !registryKey: {path: 'HKCR\ms-clicktodo', operation: delete}
+
+  - !systemPackage: {name: 'Windows-Sense*', arch: all, language: '*'}
+  - !systemPackage: {name: 'Microsoft-Windows-OneDrive*', arch: all, language: '*'}

--- a/src/Configuration/tasks/config.yml
+++ b/src/Configuration/tasks/config.yml
@@ -66,5 +66,5 @@ actions:
     exe: "LOGIN.bat"
   
   - !status: {status: 'Compressing'}
-  - !powerShell: {exe: "DISM.exe", args: "/Online /Set-ReservedStorageState /State:Disabled"}
+  - !run: {exe: "DISM.exe", args: "/Online /Set-ReservedStorageState /State:Disabled"}
   - !run: {exe: "compact.exe", args: "/CompactOS:always"}

--- a/src/Configuration/tasks/config.yml
+++ b/src/Configuration/tasks/config.yml
@@ -25,8 +25,6 @@ actions:
   - !file:
     path: "%SYSTEMDRIVE%\\Users\\Public\\Desktop\\Microsoft Edge.lnk"
   - !file:
-    path: "%ALLUSERSPROFILE%\\Microsoft\\Windows\\Start Menu\\Programs\\Accessories\\Windows Media Player.lnk"
-  - !file:
     path: "%WINDIR%\\HelpPane.exe"
   - !file:
     path: "%WINDIR%\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\SystemSettingsExtensions.dll"
@@ -66,3 +64,6 @@ actions:
   - !run:
     exeDir: true
     exe: "LOGIN.bat"
+  
+  - !status: {status: 'Compacting system component store'}
+  - !run: {exe: "compact.exe", args: "/CompactOS:always"}

--- a/src/Configuration/tasks/config.yml
+++ b/src/Configuration/tasks/config.yml
@@ -66,4 +66,5 @@ actions:
     exe: "LOGIN.bat"
   
   - !status: {status: 'Compacting system component store'}
+  - !powerShell: {exe: "DISM.exe", args: "/Online /Set-ReservedStorageState /State:Disabled"}
   - !run: {exe: "compact.exe", args: "/CompactOS:always"}

--- a/src/Configuration/tasks/config.yml
+++ b/src/Configuration/tasks/config.yml
@@ -65,6 +65,6 @@ actions:
     exeDir: true
     exe: "LOGIN.bat"
   
-  - !status: {status: 'Compacting system component store'}
+  - !status: {status: 'Compressing'}
   - !powerShell: {exe: "DISM.exe", args: "/Online /Set-ReservedStorageState /State:Disabled"}
   - !run: {exe: "compact.exe", args: "/CompactOS:always"}

--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -673,3 +673,27 @@ actions:
     path: "%windir%\\System32\\MRT.exe"
   - !file:
     path: "%windir%\\System32\\Microsoft-Edge-WebView"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-edge*"
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-windows-edge*"
+
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-windows-ie*"
+  - !file:
+    path: "%windir%\\WinSxS\\wow64_microsoft-windows-ie*"
+  - !file:
+    path: "%windir%\\WinSxS\\x86_microsoft-windows-ie*"
+  
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_microsoft-windows-onedrive*"
+
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_windows-defender*"
+  - !file:
+    path: "%windir%\\WinSxS\\wow64_windows-defender*"
+  - !file:
+    path: "%windir%\\WinSxS\\x86_windows-defender*"
+    
+  - !file:
+    path: "%windir%\\WinSxS\\amd64_windows-senseclient*"

--- a/src/Configuration/tasks/files.yml
+++ b/src/Configuration/tasks/files.yml
@@ -87,10 +87,6 @@ actions:
   - !file:
     path: "%windir%\\System32\\devicecensus.exe"
   - !file:
-    path: "%ProgramFiles(x86)%\\Windows Media Player"
-  - !file:
-    path: "%ProgramW6432%\\Windows Media Player"
-  - !file:
     path: "%ProgramFiles(x86)%\\Windows Mail"
   - !file:
     path: "%ProgramW6432%\\Windows Mail"
@@ -675,3 +671,5 @@ actions:
     path: "%windir%\\System32\\wuaueng.dll"
   - !file:
     path: "%windir%\\System32\\MRT.exe"
+  - !file:
+    path: "%windir%\\System32\\Microsoft-Edge-WebView"


### PR DESCRIPTION
This is a large PR that revamps the way components are removed.
## Component removal
There are three types of "optional" components in Windows: control.exe's Optional Features, ms-settings's Windows Capabilities (labeled in-app simply as optional features) and APPX-based System Components. It is noteworthy that some may be dependencies for normal software, so the PR should be reviewed and tested thoroughly.

### Optional features (remains in WinSxS store, user can restore):
- Work folders: unused outside of AD environments?
- .NET Framework WCF Services and TCP Port Sharing: used only by legacy software?
- Media Playback and Windows Media Player: already removed by the playbook, now removed through optional features
- SMB Direct: useless for non-server environments?
- Windows-Defender-Default-Definitions: hidden, should be removed
- NetFx4-AdvSrvs: hidden, unknown impact?

### Windows capabilities (remains in WinSxS store, user can restore):
- Steps Recorder & Math Recognizer: does anyone use these?
- Windows Media Player: already removed by above, just in case
- PowerShell ISE: does anyone use this?
- OpenCoreUAP.OneSync: appears to be syncing used by Microsoft components. Is this even useful?
- Internet Explorer: already removed as part of the playbook, just in case
- VBScript: safety hazard, should be removed.

### System components (removed **permanently**, user **cannot** restore):
- Application Compatibility Enhancements: appears to be a quite useful component that intends to replace "Run in compatibility mode", dynamically relinks DLLs, etc. Allegedly downloads updates in order to function, however. Potential safety hazard.
- AugLoop.CBS: AI component.
- CrossDevice: useless.
- UndockedDevKit: this component allegedly downloads updates to system executables such as Explorer, Notepad. I don't see how this would work with firewall settings, so remove it.
- Widgets Platform Runtime: widgets for the taskbar. Self-explanatory, kill it with fire.
- Win32WebViewHost: useless, see below.
- XboxIdentity: fixed typo, now removes properly.

## Component store deletion
This PR also supersedes #16, by removing additional components for Edge, Edge WebView, Internet Explorer, OneDrive, Defender and SenseClient from WinSxS. This is reasonable because these components are not used anyway, and uninstallation of the playbook happens with the use of a WIM image anyway, which would restore the component store to its original state. This allows to save 2+ GB of space on the system drive.
Ideally, this PR would make use of the `!systemComponent` action, however it appears to be broken and also does not support wildcards, so some dependents might have been missed.

Finally, the playbook now disables Reserved Storage, functionality used by Windows Update to ensure there's always free space on the system drive for updates to complete (just a waste of space if Windows Update is removed), and compacts the remaining system files on the drive (saves ~4 MB).