### PR TITLE
Allow Notepad to have file associations

### DIFF
--- a/src/Configuration/tasks/regedits.yml
+++ b/src/Configuration/tasks/regedits.yml
@@ -314,6 +314,9 @@ actions:
     # Disable Copilot in Notepad
   - !registryValue: {path: 'HKLM\SOFTWARE\Policies\WindowsNotepad', value: 'DisableAIFeatures', type: REG_DWORD, data: '1'}
 
+  # Restore old Notepad
+  - !registryValue: {path: 'HKLM\SOFTWARE\Classes\Applications\notepad.exe', value: 'NoOpenWith', operation: delete}
+
     # Disable opening GameBar when pressing the XBOX button on an XBOX controller
   - !registryValue: {path: 'HKCU\Software\Microsoft\GameBar', value: 'UseNexusForGameBarEnabled', type: REG_DWORD, data: '0'}
     # Disable opening GameBar when connecting XBOX controller


### PR DESCRIPTION
Classic Win32 Notepad is prohibited from having any file associations. Should the user uninstall UWP Notepad, this would resolve that.
Note: removing UWP Notepad also removes the context menu option for creating new txt files. Would/should this be reason enough to uninstall UWP Notepad by default so that the context menu option is also added by default?