### PR TITLE
Delete Windows Search (WSearch)

### DIFF
--- a/src/Configuration/tasks/components.yml
+++ b/src/Configuration/tasks/components.yml
@@ -493,8 +493,6 @@ actions:
   - !file: {path: '%windir%\\System32\\SearchFilterHost.exe'}
   - !file: {path: '%windir%\\SysWOW64\\SearchProtocolHost.exe'}
   - !file: {path: '%ProgramData%\\Microsoft\\Search'}
-  - !registrykey: {path: 'HKLM\SOFTWARE\Microsoft\Windows Search', operation: delete}
-  - !registrykey: {path: 'HKLM\SOFTWARE\Microsoft\Windows Search', operation: delete}
   - !scheduledTask:
     path: "\\Microsoft\\Windows\\Shell\\IndexerAutomaticMaintenance"
     operation: delete

--- a/src/Configuration/tasks/components.yml
+++ b/src/Configuration/tasks/components.yml
@@ -483,3 +483,18 @@ actions:
   - !registryKey: {path: 'HKCR\ms-office-ai', operation: delete}
   - !registryKey: {path: 'HKCR\ms-copilot', operation: delete}
   - !registryKey: {path: 'HKCR\ms-clicktodo', operation: delete}
+
+  # Windows Search
+  - !service:
+    name: "WSearch"
+    operation: delete
+  - !file: {path: '%windir%\\System32\\SearchIndexer.exe'}
+  - !file: {path: '%windir%\\System32\\SearchProtocolHost.exe'}
+  - !file: {path: '%windir%\\System32\\SearchFilterHost.exe'}
+  - !file: {path: '%windir%\\SysWOW64\\SearchProtocolHost.exe'}
+  - !file: {path: '%ProgramData%\\Microsoft\\Search'}
+  - !registrykey: {path: 'HKLM\SOFTWARE\Microsoft\Windows Search', operation: delete}
+  - !registrykey: {path: 'HKLM\SOFTWARE\Microsoft\Windows Search', operation: delete}
+  - !scheduledTask:
+    path: "\\Microsoft\\Windows\\Shell\\IndexerAutomaticMaintenance"
+    operation: delete


### PR DESCRIPTION
This is a divisive PR.
Reasons to do so:
- Windows Search is famously slow, whether that be its taskbar counterpart (which works just fine for programs if WSearch is removed, albeit with a warning window) or the Explorer search bar.
- [Everything by voidtools](https://www.voidtools.com/) performs the same search operations, but faster, better and more lightweight, and has been doing so for at least a decade.
- Search indexing uses, as the name suggests, indexing in order to be aware of files on the system, which wastes resources and time. Everything uses the NTFS MFT, which is a natural part of the filesystem.
- Most people _probably_ don't search their files anyway.

Reasons **not** to do so:
- Windows Search is built-in. If a user, god forbid, needs to search for his files, he might be surprised why it doesn't work.
- Windows Search is capable of indexing file contents as well (though it's just as slow with that). It _might_ also work with non-NTFS volumes (but Everything also can index non-NTFS volumes like WSearch does).
- Everything is not open source software. It also doesn't come pre-installed with the system.
- Everything has limitations:
> While all NTFS/ReFS hard links are indexed, changes made to a hard link will only update the first hard link entry in "Everything".
> "Everything" does not follow junctions with NTFS/ReFS indexing.

Ideally, these points should be weighed (incl. community feedback) before this PR is either merged or closed.