### PR TITLE
Disable EdgeUpdate and stop Edge from coming back

### DIFF
--- a/src/Configuration/tasks/components.yml
+++ b/src/Configuration/tasks/components.yml
@@ -131,6 +131,20 @@ actions:
   - !registryKey: {path: 'HKCU\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}'}
   - !registryKey: {path: 'HKCU\SOFTWARE\Microsoft\Edge'}
 
+  # Disable automatic updates, stop Edge from coming back
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Install{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Update{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Uninstall{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}', type: REG_DWORD, data: '2'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Install{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Update{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Install{65C35B14-6C1D-4122-AC46-7148CC9D6497}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Update{65C35B14-6C1D-4122-AC46-7148CC9D6497}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Install{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Update{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Install{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', type: REG_DWORD, data: '4'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'Update{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', type: REG_DWORD, data: '0'}
+  - !registryValue: {path: 'HKLM\SOFTWARE\Policies\Microsoft\EdgeUpdate', value: 'AutoUpdateCheckPeriodMinutes', type: REG_DWORD, data: '0'}
+
   - !run: {exeDir: true, exe: "EDGE.bat", weight: 20}
 
   - !file:


### PR DESCRIPTION
Edge has a list of "business" policies that allow to regulate how EdgeUpdate works. This PR prevents any versions of Edge from being installed at all (and, if Edge is installed, it will automatically delete itself and any user data produced by it) and stops EdgeUpdate from working.

Additionally, Edge WebView is prevented from installing inside user directories and must be installed machine-wide. This is intended so that a system-wide dependency like a webview will not be subject to user profile quirks.